### PR TITLE
Make dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 venv
 .env
+.env.local
 data
 __pycache__
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+REDIS_CONTAINER_NAME=redis-dev
+
+
 start-backend:
 	cd backend && \
 	python3 -m venv venv && \
@@ -10,13 +13,22 @@ start-frontend:
 	npm install && \
 	npm run dev
 
+
+start-worker:
+	cd backend && python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt && python worker.py -f
+
+
+
+# Mock
+
 start-mock:
 	cd mock_backend && \
 	npm install && \
 	node server.js
 	
-start-worker:
-	cd backend && python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt && python worker.py
+# Redis
+start-local-redis:
+	docker run -d --rm --name $(REDIS_CONTAINER_NAME) -p 6379:6379 redis:7
 
-deploy-backend:
-	cd backend && flyctl deploy
+stop-local-redis:
+	docker stop $(REDIS_CONTAINER_NAME)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+GH_TOKEN="github_pat_XXX"
+
+REDIS_URL=rediss://default:AXXX
+
+GHCR_TOKEN = "ghp_XXX"

--- a/backend/.env.local.example
+++ b/backend/.env.local.example
@@ -1,0 +1,1 @@
+REDIS_URL=redis://localhost:6379

--- a/backend/app/services/github_service_mock.py
+++ b/backend/app/services/github_service_mock.py
@@ -1,0 +1,31 @@
+from app.models.issue_model import Issue, RepositoryInfo
+import datetime
+
+async def fetch_mock_issues() -> list[Issue]:
+    issues = []
+    now = datetime.datetime.utcnow().isoformat() + "Z"
+
+    for i in range(1, 1000):
+        issues.append(Issue(
+            title=f"Mock issue #{i}: This is a mock issue. Set env var USE_MOCK_GITHUB_API to false for real issues",
+            url=f"https://github.com/mock/repo/issues/{i}",
+            createdAt=now,
+            updatedAt=now,
+            labels=["good first issue", "mock"],
+            commentsCount=0,
+            isAssigned=False,
+            repository=RepositoryInfo(
+                name="mock-repo",
+                fullName="mock/repo",
+                description="Mock repo for testing",
+                owner="mock",
+                stars=42,
+                language="Python",
+                topics=["mock", "testing"],
+                lastCommit=now,
+                visibility="PUBLIC",
+            ),
+            organization="mock"
+        ))
+
+    return issues

--- a/backend/app/services/issues_store.py
+++ b/backend/app/services/issues_store.py
@@ -6,7 +6,8 @@ from app.models.issue_model import Issue
 from dotenv import load_dotenv
 import time
 
-load_dotenv()
+load_dotenv(".env.local", override=True)
+load_dotenv(".env")
 
 REDIS_URL = os.getenv("REDIS_URL")
 REDIS_KEY = "goodfirstissue"

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,3 +1,4 @@
+import argparse
 import asyncio
 import time
 from app.services.github_service import fetch_all_issues_from_github
@@ -8,6 +9,7 @@ from app.services.issues_store import (
 )
 
 REFRESH_INTERVAL = 6 * 60 * 60  # 6 hours in seconds
+
 
 async def refresh_issues():
     print("🔄 Starting refresh cycle...")
@@ -27,29 +29,50 @@ async def refresh_issues():
     except Exception as e:
         print(f"❌ Error during refresh: {e}")
 
-async def refresh_loop():
+
+async def refresh_loop(force: bool = False):
     print("🚀 Worker started successfully. Beginning refresh loop.")
+
+    if force:
+        print("⚡ Force refresh enabled. Skipping wait and refreshing immediately.")
+        await refresh_issues()
+        print(
+            f"⏳ Sleeping for {REFRESH_INTERVAL / 3600:.1f} hours until next refresh..."
+        )
+        await asyncio.sleep(REFRESH_INTERVAL)
 
     while True:
         last_updated = await get_last_updated_timestamp()
         now = int(time.time())
-        
+
         if last_updated:
             elapsed_time = now - last_updated
             if elapsed_time < REFRESH_INTERVAL:
                 sleep_for = REFRESH_INTERVAL - elapsed_time
-                print(f"⏳ Last refresh was {elapsed_time/3600:.2f} hours ago. Sleeping for {sleep_for/3600:.2f} more hours...")
+                print(
+                    f"⏳ Last refresh was {elapsed_time / 3600:.2f} hours ago. Sleeping for {sleep_for / 3600:.2f} more hours..."
+                )
                 await asyncio.sleep(sleep_for)
 
-
         await refresh_issues()
-
-        print(f"⏳ Sleeping for {REFRESH_INTERVAL / 3600:.1f} hours until next refresh...")
+        print(
+            f"⏳ Sleeping for {REFRESH_INTERVAL / 3600:.1f} hours until next refresh..."
+        )
         await asyncio.sleep(REFRESH_INTERVAL)
 
+
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Start the GitHub issue refresh worker."
+    )
+    parser.add_argument(
+        "-f", "--force", action="store_true", help="Force immediate refresh on start"
+    )
+
+    args = parser.parse_args()
+
     try:
-        asyncio.run(refresh_loop())
+        asyncio.run(refresh_loop(force=args.force))
     except KeyboardInterrupt:
         print("👋 Worker shutdown requested. Exiting gracefully.")
     except Exception as e:


### PR DESCRIPTION
This PR enhances the local development experience. Previously, local + prod was using the Remote Hosted Redis DB. Also, using GitHub GraphQH APIs for local dev which requires GH tokens. This makes it harder to get started with local dev.

In this PR:
- Added a Make command to start a REDIS server in local system using Docker. Devs can set this to be the Redis URL in the env variables
- Added a env variable flag USE_MOCK_GITHUB_API to ensure that the dev can use Mock data while dev and testing without the need of getting a GH token. Setting this to true bypasses the need for a token and dummy data gets used.
- Added env.local.example

Dependencies Introduced:
- For local dev, to run the Redis server, Docker will now be required